### PR TITLE
Show friendly error when server is offline

### DIFF
--- a/packages/frontend/src/lib/api.ts
+++ b/packages/frontend/src/lib/api.ts
@@ -92,11 +92,18 @@ async function request<T>(
   const token = getToken();
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
-  const res = await fetch(`${API_URL}${path}`, {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch {
+    throw new Error(
+      "Cannot connect to server. The server may be offline — please try again later.",
+    );
+  }
 
   if (!res.ok) {
     const text = await res.text();
@@ -134,11 +141,18 @@ async function requestFormData<T>(
   const token = getToken();
   if (token) headers["Authorization"] = `Bearer ${token}`;
 
-  const res = await fetch(`${API_URL}${path}`, {
-    method,
-    headers,
-    body: formData,
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}${path}`, {
+      method,
+      headers,
+      body: formData,
+    });
+  } catch {
+    throw new Error(
+      "Cannot connect to server. The server may be offline — please try again later.",
+    );
+  }
 
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Changes

Wraps fetch calls in try-catch blocks in the API module to handle connection errors gracefully.

### Details

- Updated `request()` function to catch fetch errors and throw a user-friendly error message
- Updated `requestFormData()` function with the same error handling pattern
- When the server is unreachable, users now see: "Cannot connect to server. The server may be offline — please try again later."

### Files Modified

- `packages/frontend/src/lib/api.ts` - Added error handling to both request functions