### PR TITLE
Add configurable CORS origins and fix cloudflared networking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,13 @@ INITIAL_ADMIN_BOOTSTRAP_TOKEN=change-me-before-first-signup
 # DEFAULT_CREDITS_NZD=1.00
 
 # -----------------------------------------------------------------------------
+# CORS (optional — add extra frontend origins beyond the built-in defaults)
+# -----------------------------------------------------------------------------
+# Built-in defaults: https://gpu-share.vercel.app, http://localhost:5173, http://localhost:3000
+# Add comma-separated extra origins here if you deploy the frontend elsewhere:
+CORS_ORIGINS=
+
+# -----------------------------------------------------------------------------
 # Cloudflare Tunnel (optional — for permanent URLs)
 # -----------------------------------------------------------------------------
 TUNNEL_TOKEN=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
   cloudflared:
     image: cloudflare/cloudflared:latest
     command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    network_mode: host
     depends_on:
       - fastapi
     restart: unless-stopped

--- a/packages/server/app/config.py
+++ b/packages/server/app/config.py
@@ -65,6 +65,11 @@ class Settings(BaseSettings):
     # ── Skills ────────────────────────────────────────────────────────────
     SKILLS_DIR: str = "skills"
 
+    # ── CORS ─────────────────────────────────────────────────────────────
+    # Extra comma-separated origins to allow (in addition to the built-in defaults).
+    # Example: CORS_ORIGINS=https://my-app.vercel.app,https://staging.example.com
+    CORS_ORIGINS: str = ""
+
     # ── Cloudflare Tunnel ────────────────────────────────────────────────
     TUNNEL_TOKEN: str = ""
 

--- a/packages/server/app/main.py
+++ b/packages/server/app/main.py
@@ -44,13 +44,17 @@ app = FastAPI(
 app.state.limiter = auth.limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+_default_origins = [
+    "https://gpu-share.vercel.app",
+    "http://localhost:5173",
+    "http://localhost:3000",
+]
+_extra_origins = [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
+_allowed_origins = _default_origins + _extra_origins
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "https://gpu-share.vercel.app",
-        "http://localhost:5173",
-        "http://localhost:3000",
-    ],
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
This PR adds support for configurable CORS origins via environment variables while maintaining built-in defaults, and fixes cloudflared networking configuration in Docker Compose.

## Key Changes
- **CORS Configuration**: Introduced `CORS_ORIGINS` environment variable to allow operators to specify additional frontend origins beyond the built-in defaults (gpu-share.vercel.app, localhost:5173, localhost:3000)
  - Added `CORS_ORIGINS` setting to `config.py` with empty string default
  - Updated `main.py` to parse comma-separated origins and merge with defaults
  - Documented the feature in `.env.example` with examples and built-in defaults listed

- **Docker Compose**: Added `network_mode: host` to the cloudflared service to ensure proper network connectivity

## Implementation Details
- The CORS origins are processed by stripping whitespace from comma-separated values, allowing flexible formatting
- Built-in defaults are always included; extra origins are appended to maintain backward compatibility
- The configuration is flexible enough to support both single and multiple additional origins

https://claude.ai/code/session_01EXeMppWQhFREUbdeDA867k