### PR TITLE
Add OpenCode integration with auto-routing model

### DIFF
--- a/packages/frontend/src/pages/account.tsx
+++ b/packages/frontend/src/pages/account.tsx
@@ -112,7 +112,7 @@ export function AccountPage() {
   );
   const [dismissed, setDismissed] = useState(false);
   const [guideTab, setGuideTab] = useState<
-    "curl" | "python" | "claude-code" | "openclaw"
+    "curl" | "python" | "claude-code" | "openclaw" | "opencode"
   >("curl");
   const [editName, setEditName] = useState("");
   const [editEmail, setEditEmail] = useState("");
@@ -353,6 +353,10 @@ export ANTHROPIC_AUTH_TOKEN="${revealedKey}"
     null,
     2,
   );
+
+  const openCodeBashSnippet = `curl -fsSL ${API_URL}/setup-opencode.sh | bash -s -- --key "${revealedKey}" --url "${API_URL}"`;
+
+  const openCodePsSnippet = `irm ${API_URL}/setup-opencode.ps1 -OutFile setup.ps1; .\\setup.ps1 -Key "${revealedKey}" -Url "${API_URL}"`;
 
   // Donut chart percentages
   const totalCostForDonut = usageStats.inferenceCost + usageStats.renderCost;
@@ -763,6 +767,7 @@ export ANTHROPIC_AUTH_TOKEN="${revealedKey}"
                     { key: "python", label: "Python" },
                     { key: "claude-code", label: "Claude Code" },
                     { key: "openclaw", label: "OpenClaw" },
+                    { key: "opencode", label: "OpenCode" },
                   ] as const
                 ).map((tab) => (
                   <button
@@ -894,6 +899,64 @@ export ANTHROPIC_AUTH_TOKEN="${revealedKey}"
                       >
                         View Setup Guide
                       </a>
+                    </div>
+                  </div>
+                )}
+
+                {guideTab === "opencode" && (
+                  <div className="bg-white border border-[#E5E1DB] rounded-lg p-3">
+                    <div className="flex items-center gap-2 mb-2">
+                      <span className="text-sm font-medium">OpenCode</span>
+                    </div>
+                    <p className="text-xs text-[#6F6B66] mb-2">
+                      One-command setup. Installs OpenCode and configures it
+                      with GPUShare smart auto-routing.
+                    </p>
+                    <div className="space-y-3">
+                      <div>
+                        <p className="text-xs font-medium text-[#2D2B28] mb-1">
+                          Linux / macOS
+                        </p>
+                        <pre className="bg-[#F4F3EE] border border-[#E5E1DB] rounded-lg p-3 text-xs text-[#2D2B28] overflow-x-auto whitespace-pre-wrap">
+                          {openCodeBashSnippet}
+                        </pre>
+                        <Button
+                          onClick={() => {
+                            navigator.clipboard.writeText(openCodeBashSnippet);
+                            trigger("nudge");
+                          }}
+                          variant="ghost"
+                          size="sm"
+                          className="w-full text-xs"
+                        >
+                          Copy Bash Command
+                        </Button>
+                      </div>
+                      <div>
+                        <p className="text-xs font-medium text-[#2D2B28] mb-1">
+                          Windows PowerShell
+                        </p>
+                        <pre className="bg-[#F4F3EE] border border-[#E5E1DB] rounded-lg p-3 text-xs text-[#2D2B28] overflow-x-auto whitespace-pre-wrap">
+                          {openCodePsSnippet}
+                        </pre>
+                        <Button
+                          onClick={() => {
+                            navigator.clipboard.writeText(openCodePsSnippet);
+                            trigger("nudge");
+                          }}
+                          variant="ghost"
+                          size="sm"
+                          className="w-full text-xs"
+                        >
+                          Copy PowerShell Command
+                        </Button>
+                      </div>
+                      <p className="text-xs text-[#6F6B66]">
+                        Uses the "auto" model — routes simple prompts to fast
+                        local models and complex tasks to powerful models. Type{" "}
+                        <code className="bg-[#F4F3EE] px-1 rounded">/models</code>{" "}
+                        inside OpenCode to switch models manually.
+                      </p>
                     </div>
                   </div>
                 )}

--- a/packages/server/app/main.py
+++ b/packages/server/app/main.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import PlainTextResponse
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
@@ -67,6 +70,27 @@ app.include_router(admin.router)
 app.include_router(invite.router)
 app.include_router(skills.router)
 app.include_router(model_picker.router)
+
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+
+
+@app.get("/setup-opencode.sh", response_class=PlainTextResponse, tags=["setup"])
+async def setup_opencode_bash():
+    """Serve the OpenCode setup script for Linux/macOS."""
+    return PlainTextResponse(
+        (_SCRIPTS_DIR / "setup-opencode.sh").read_text(),
+        media_type="text/x-shellscript",
+    )
+
+
+@app.get("/setup-opencode.ps1", response_class=PlainTextResponse, tags=["setup"])
+async def setup_opencode_powershell():
+    """Serve the OpenCode setup script for Windows."""
+    return PlainTextResponse(
+        (_SCRIPTS_DIR / "setup-opencode.ps1").read_text(),
+        media_type="text/plain",
+    )
 
 
 @app.get("/health")

--- a/packages/server/app/routers/inference.py
+++ b/packages/server/app/routers/inference.py
@@ -78,6 +78,53 @@ def _to_openrouter_message(m) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Auto-model routing
+# ---------------------------------------------------------------------------
+
+AUTO_TOKEN_THRESHOLD = 2000
+
+
+async def _resolve_auto_model(input_tokens: int) -> tuple[str, bool]:
+    """Pick a real model when the user requests 'auto'.
+
+    Returns (model_name, use_openrouter).
+    Small prompts (< threshold) → lightest local model.
+    Large prompts (>= threshold) → heaviest local model or first OpenRouter model.
+    """
+    settings = get_settings()
+
+    try:
+        local_models = await ollama_list_models()
+    except Exception:
+        local_models = []
+
+    or_models: list[dict] = []
+    if settings.OPENROUTER_API_KEY:
+        try:
+            or_models = await openrouter_list_models()
+        except Exception:
+            pass
+
+    if input_tokens < AUTO_TOKEN_THRESHOLD:
+        # Light: prefer first (smallest) local model
+        if local_models:
+            return local_models[0], False
+        if or_models:
+            return or_models[0]["id"], True
+    else:
+        # Heavy: prefer OpenRouter if available, else largest local model
+        if or_models:
+            return or_models[0]["id"], True
+        if local_models:
+            return local_models[-1], False
+
+    # Fallback
+    if local_models:
+        return local_models[0], False
+    raise HTTPException(status_code=503, detail="No models available for auto routing")
+
+
+# ---------------------------------------------------------------------------
 # POST /chat/completions
 # ---------------------------------------------------------------------------
 
@@ -102,6 +149,11 @@ async def create_chat_completion(
     # Count input tokens (text parts only)
     input_text = " ".join(_extract_text(m.content) for m in body.messages)
     input_tokens = count_tokens(input_text)
+
+    # Resolve "auto" to a real model
+    if body.model == "auto":
+        resolved_model, _ = await _resolve_auto_model(input_tokens)
+        body = body.model_copy(update={"model": resolved_model})
 
     use_openrouter = is_openrouter_model(body.model) and settings.OPENROUTER_API_KEY
     if use_openrouter:
@@ -347,6 +399,15 @@ async def list_models(
     """Return only models that are actually available (local + OpenRouter)."""
     settings = get_settings()
     models: list[ModelInfo] = []
+
+    # Virtual "auto" model — smart routing (always first)
+    models.append(ModelInfo(
+        id="auto",
+        owned_by="gpushare",
+        cost_per_million_tokens=0,
+        loaded=True,
+        vision_support=False,
+    ))
 
     # Local Ollama models — only those actually loaded
     try:

--- a/packages/server/scripts/setup-opencode.ps1
+++ b/packages/server/scripts/setup-opencode.ps1
@@ -1,0 +1,42 @@
+# Setup script for OpenCode with GPUShare (Windows)
+# Usage: irm https://your-site.com/setup-opencode.ps1 -OutFile setup.ps1; .\setup.ps1 -Key "YOUR_KEY" -Url "https://your-site.com"
+
+param(
+    [Parameter(Mandatory=$true)][string]$Key,
+    [Parameter(Mandatory=$true)][string]$Url
+)
+
+# Strip trailing slash
+$Url = $Url.TrimEnd('/')
+
+# Install OpenCode if missing
+if (-not (Get-Command opencode -ErrorAction SilentlyContinue)) {
+    Write-Host "Installing OpenCode..."
+    iex "& {$(irm https://opencode.ai/install.ps1)} "
+}
+
+# Write Config
+$confPath = "$env:USERPROFILE\.config\opencode"
+if (-not (Test-Path $confPath)) { New-Item -ItemType Directory -Path $confPath -Force | Out-Null }
+
+$config = @{
+    provider = @{
+        gpushare = @{
+            npm = "@ai-sdk/openai-compatible"
+            options = @{
+                baseURL = "$Url/v1"
+                apiKey = $Key
+            }
+        }
+    }
+    model = "gpushare/auto"
+} | ConvertTo-Json -Depth 10
+
+$config | Out-File "$confPath\opencode.json" -Encoding utf8
+
+Write-Host "OpenCode configured with GPUShare!" -ForegroundColor Green
+Write-Host "  Model: gpushare/auto (smart routing)"
+Write-Host "  API:   $Url/v1"
+Write-Host ""
+Write-Host "Run 'opencode' in any project folder to start."
+Write-Host "Tip: Type /models inside OpenCode to switch models."

--- a/packages/server/scripts/setup-opencode.sh
+++ b/packages/server/scripts/setup-opencode.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Setup script for OpenCode with GPUShare
+# Usage: curl -fsSL https://your-site.com/setup-opencode.sh | bash -s -- --key "YOUR_KEY" --url "https://your-site.com"
+
+set -euo pipefail
+
+API_KEY=""
+API_URL=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --key) API_KEY="$2"; shift 2 ;;
+        --url) API_URL="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [ -z "$API_KEY" ]; then
+    echo "Error: API key required."
+    echo "Usage: curl -fsSL <url>/setup-opencode.sh | bash -s -- --key YOUR_KEY --url https://your-gpushare.com"
+    exit 1
+fi
+
+if [ -z "$API_URL" ]; then
+    echo "Error: --url is required (e.g., --url https://your-gpushare-instance.com)"
+    exit 1
+fi
+
+# Strip trailing slash from URL
+API_URL="${API_URL%/}"
+
+# Install OpenCode if missing
+if ! command -v opencode &> /dev/null; then
+    echo "Installing OpenCode..."
+    curl -fsSL https://opencode.ai/install | bash
+fi
+
+# Write Config
+CONF_DIR="$HOME/.config/opencode"
+mkdir -p "$CONF_DIR"
+
+cat <<EOF > "$CONF_DIR/opencode.json"
+{
+  "provider": {
+    "gpushare": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "${API_URL}/v1",
+        "apiKey": "${API_KEY}"
+      }
+    }
+  },
+  "model": "gpushare/auto"
+}
+EOF
+
+echo "OpenCode configured with GPUShare!"
+echo "  Model: gpushare/auto (smart routing)"
+echo "  API:   ${API_URL}/v1"
+echo ""
+echo "Run 'opencode' in any project folder to start."
+echo "Tip: Type /models inside OpenCode to switch models."


### PR DESCRIPTION
## Summary

- **Auto model**: Adds a virtual `auto` model to `/v1/models` that intelligently routes requests — small prompts (< 2000 tokens) go to the lightest local Ollama model, large/complex prompts go to the heaviest local model or first OpenRouter model
- **Setup scripts**: New `setup-opencode.sh` (bash) and `setup-opencode.ps1` (PowerShell) that install OpenCode CLI and configure it to use GPUShare with the `gpushare/auto` provider
- **Script endpoints**: `GET /setup-opencode.sh` and `GET /setup-opencode.ps1` serve the scripts directly from the backend
- **Frontend tab**: New "OpenCode" tab in the API key creation UI showing one-liner setup commands for Linux/macOS and Windows, with copy buttons

## Test plan

- [ ] Verify `GET /v1/models` returns `auto` as the first model in the list
- [ ] Send `POST /v1/chat/completions` with `"model": "auto"` and a short prompt — confirm it routes to a light model
- [ ] Send `POST /v1/chat/completions` with `"model": "auto"` and a long prompt — confirm it routes to a heavier model
- [ ] Verify `GET /setup-opencode.sh` returns the bash script
- [ ] Verify `GET /setup-opencode.ps1` returns the PowerShell script
- [ ] Create a new API key on the account page and verify the "OpenCode" tab appears with correct snippets

https://claude.ai/code/session_01Dp2VEFDTRod3UTAESKSzBa